### PR TITLE
Generalize Geometry Column Handling in Preprocessing

### DIFF
--- a/core2/preprocessing.py
+++ b/core2/preprocessing.py
@@ -155,7 +155,7 @@ def calculateBoundaryWeight(polygonsInArea, scale_polygon = 1.5, output_plot = T
     new_c = []
     #for each polygon in area scale, compare with other polygons:
     for i in tqdm(range(len(tempPolygonDf))):
-        pol1 = gps.GeoSeries(tempPolygonDf.iloc[i][0])
+        pol1 = gps.GeoSeries(tempPolygonDf.iloc[i]['geometry'])
         sc = pol1.scale(xfact=scale_polygon, yfact=scale_polygon, zfact=scale_polygon, origin='center')
         scc = pd.DataFrame(columns=['id', 'geometry'])
         scc = scc.append({'id': None, 'geometry': sc[0]}, ignore_index=True)


### PR DESCRIPTION
When preparing local fine-tuning datasets using ArcGIS Pro, the geometry column of the output polygons (`tempPolygonDf `) may not always reside in the first positional column (`[0]`). To improve robustness and avoid hard-coded index dependencies.

- **Change**: Updated `tempPolygonDf.iloc[i][0]` → `tempPolygonDf.iloc[i]['geometry']` in preprocessing.py. 