### PR TITLE
Remove .drop(column="id") from tempPolygonDf

### DIFF
--- a/core2/preprocessing.py
+++ b/core2/preprocessing.py
@@ -151,7 +151,7 @@ def calculateBoundaryWeight(polygonsInArea, scale_polygon = 1.5, output_plot = T
         return gps.GeoDataFrame({})
     tempPolygonDf = pd.DataFrame(polygonsInArea)
     tempPolygonDf.reset_index(drop=True,inplace=True)
-    tempPolygonDf = gps.GeoDataFrame(tempPolygonDf.drop(columns=['id']))
+    tempPolygonDf = gps.GeoDataFrame(tempPolygonDf)
     new_c = []
     #for each polygon in area scale, compare with other polygons:
     for i in tqdm(range(len(tempPolygonDf))):


### PR DESCRIPTION
This can fix the issue [`KeyError: "['id'] not found in axis"`](https://github.com/sizhuoli/TreeCountSegHeight/issues/20#issuecomment-2690435975). Since `tempPolygonDf `does not necessarily contain column `id`. **Not** dropping column `id` does not has any impact on the following processing as far as I am aware.